### PR TITLE
update readme, prompt, and git aliases

### DIFF
--- a/.files/prompt_megthommes_setup
+++ b/.files/prompt_megthommes_setup
@@ -61,7 +61,13 @@ prompt_git_branch() {
 
 # display git info
 prompt_git_info() {
-    [ ! -z "$vcs_info_msg_0_" ] && echo "$ZSH_THEME_GIT_PROMPT_PREFIX%B%F{yellow}$vcs_info_msg_0_%f%b$ZSH_THEME_GIT_PROMPT_SUFFIX"
+    if [ ! -z "$vcs_info_msg_0_" ]; then
+        local branch_color="{yellow}"
+        if [ "$vcs_info_msg_0_" = "main" ]; then
+            branch_color="{red}"
+        fi
+        echo "$ZSH_THEME_GIT_PROMPT_PREFIX%B%F${branch_color}$vcs_info_msg_0_%f%b$ZSH_THEME_GIT_PROMPT_SUFFIX"
+    fi
 }
 
 # display git status

--- a/.shell_aliases/git.zsh
+++ b/.shell_aliases/git.zsh
@@ -16,9 +16,9 @@ alias gc='git commit'                       # commit changes
 alias gca='git commit --amend'              # amend the last commit
 alias gd='git diff'                         # show diff of unstaged changes
 # checkout branch or create it if it doesn't exist
-alias gco="!f() { git checkout -b \"$1\" 2> /dev/null || git checkout \"$1\"; }; f"
-alias gsub="git submodule update --remote" # pull submodules
-alias gclone="git clone --recursive"       # clone repository including all submodules
+alias gco='f() { git checkout -b "$1" 2> /dev/null || git checkout "$1"; }; f'
+alias gsub="git submodule update --remote"  # pull submodules
+alias gclone="git clone --recursive"        # clone repository including all submodules
 
 # branch management
 alias gb='git branch '     # list or manipulate branches

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository contains my personal dotfiles and configuration files for my dev
 $ cd ~
 $ git clone git@github.com:megthommes/dotfiles
 $ cd dotfiles
-$ ./install.zsh
+$ ./install.sh
 ```
 
 ### For others
@@ -36,7 +36,7 @@ If you have SSH access enabled:
 ```sh
 $ git clone git@github.com:YOUR-USERNAME/dotfiles
 $ cd dotfiles
-$ ./install.zsh
+$ ./install.sh
 ```
 
 If you don't have SSH access enabled:
@@ -44,5 +44,5 @@ If you don't have SSH access enabled:
 ```sh
 $ git clone https://github.com/YOUR-USERNAME/dotfiles
 $ cd dotfiles
-$ ./install.zsh
+$ ./install.sh
 ```


### PR DESCRIPTION
README: Fixed typo in installation instructions (install.**zsh** --> install.**sh**)

git.zsh: fixed typo in `gco` alias

prompt_megthommes_setup: changed branch color to red if on main