### PR TITLE
Update prompt

### DIFF
--- a/.files/.zshrc
+++ b/.files/.zshrc
@@ -34,6 +34,7 @@ setopt HIST_SAVE_NO_DUPS         # Do not write a duplicate event to the history
 setopt HIST_VERIFY               # Do not execute immediately upon history expansion.
 
 # plugins
+source $ZDOTDIR/.plugins/completion.zsh
 for plugin_dir in $ZDOTDIR/.plugins/*(/); do
     if [[ ${plugin_dir:t} == "zsh-completions" ]]; then
         fpath=("$plugin_dir/src" $fpath)
@@ -43,6 +44,9 @@ for plugin_dir in $ZDOTDIR/.plugins/*(/); do
         source "$plugin_dir/${plugin_dir:t}.zsh"
     fi
 done
+
+# Set up key bindings for completion
+bindkey '^[[Z' autosuggest-accept # Shift+Tab
 
 # direnv
 eval "$(direnv hook zsh)"

--- a/.files/prompt_megthommes_setup
+++ b/.files/prompt_megthommes_setup
@@ -1,9 +1,9 @@
 # Personalized prompt
 
 # Based on:
-# megthommes
+# Purity
 # by Kevin Lanni
-# https://github.com/therealklanni/megthommes
+# https://github.com/therealklanni/purity
 # MIT License
 # and
 # Purification

--- a/.files/prompt_megthommes_setup
+++ b/.files/prompt_megthommes_setup
@@ -61,7 +61,13 @@ prompt_git_branch() {
 
 # display git info
 prompt_git_info() {
-    [ ! -z "$vcs_info_msg_0_" ] && echo "$ZSH_THEME_GIT_PROMPT_PREFIX%B%F{yellow}$vcs_info_msg_0_%f%b$ZSH_THEME_GIT_PROMPT_SUFFIX"
+    if [ ! -z "$vcs_info_msg_0_" ]; then
+        local branch_color="{yellow}"
+        if [ "$vcs_info_msg_0_" = "main" ]; then
+            branch_color="{red}"
+        fi
+        echo "$ZSH_THEME_GIT_PROMPT_PREFIX%B%F${branch_color}$vcs_info_msg_0_%f%b$ZSH_THEME_GIT_PROMPT_SUFFIX"
+    fi
 }
 
 # display git status
@@ -136,7 +142,10 @@ prompt_precmd() {
     print -Pn '\e]0;%~\a'
 
     local prompt_megthommes_preprompt="%c$(prompt_git_branch) $(prompt_git_status)"
-    print -P ' %F{yellow}$(prompt_cmd_exec_time)%f'
+
+    # only print execution time if it's non-empty
+    local exec_time=$(prompt_cmd_exec_time)
+    [[ -n "$exec_time" ]] && print -P '%F{yellow}${exec_time}%f'
 
     # check async if there is anything to pull
     (( ${PROMPT_GIT_PULL:-1} )) && {

--- a/.plugins/completion.zsh
+++ b/.plugins/completion.zsh
@@ -1,7 +1,7 @@
 # Sets completion options.
 
 # load additional zsh-completions
-fpath=($ZDOTDIR/zsh/plugins/zsh-completions/src $fpath)
+fpath=($ZDOTDIR/.plugins/zsh-completions/src $fpath)
 
 # call before compinit
 zmodload zsh/complist

--- a/.plugins/completion.zsh
+++ b/.plugins/completion.zsh
@@ -6,9 +6,8 @@ fpath=($ZDOTDIR/.plugins/zsh-completions/src $fpath)
 # call before compinit
 zmodload zsh/complist
 
-# load default zsh-completions
-autoload -U compinit; compinit
-_comp_options+=(globdots) # with hidden files
+# Include hidden files in completion
+_comp_options+=(globdots)
 
 #
 # Options
@@ -119,3 +118,6 @@ zstyle ':completion:*:ssh:*' group-order users hosts-domain hosts-host users hos
 zstyle ':completion:*:(ssh|scp|rsync):*:hosts-host' ignored-patterns '*(.|:)*' loopback ip6-loopback localhost ip6-localhost broadcasthost
 zstyle ':completion:*:(ssh|scp|rsync):*:hosts-domain' ignored-patterns '<->.<->.<->.<->' '^[-[:alnum:]]##(.[-[:alnum:]]##)##' '*@*'
 zstyle ':completion:*:(ssh|scp|rsync):*:hosts-ipaddr' ignored-patterns '^(<->.<->.<->.<->|(|::)([[:xdigit:].]##:(#c,2))##(|%*))' '127.0.0.<->' '255.255.255.255' '::1' 'fe80::*'
+
+# Initialize the completion system
+autoload -Uz compinit && compinit


### PR DESCRIPTION
- Fixed typos in `prompt_megthommes_setup`
- Removed lines caused by no execution time being shown
- Sourced `completion.zsh` so that completions actually occur
- Updated key bindings to use `Shift + Tab` in addition to the right arrow for completions
- Moved initialization of the completion system to the end of `completions.zsh`